### PR TITLE
feat: containerise s3 client generation, support other client credentials

### DIFF
--- a/src/Http/Controllers/UploadController.php
+++ b/src/Http/Controllers/UploadController.php
@@ -3,7 +3,6 @@
 namespace Ahmedkandel\NovaS3MultipartUpload\Http\Controllers;
 
 use Ahmedkandel\NovaS3MultipartUpload\NovaS3MultipartUpload;
-use Aws\S3\S3Client;
 use Illuminate\Support\Str;
 use Laravel\Nova\Http\Requests\NovaRequest;
 
@@ -19,7 +18,7 @@ class UploadController
     /**
      * S3 client instance.
      *
-     * @var \Aws\S3\S3Client
+     * @var \Aws\S3\S3ClientInterface
      */
     private $s3Client;
 
@@ -36,10 +35,10 @@ class UploadController
     /**
      * Retrieve resource tool and Authorize then create S3Client..
      *
-     * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
+     * @param \Laravel\Nova\Http\Requests\NovaRequest $request
      * @return void
      */
-    private function init($request)
+    protected function init($request)
     {
         $resource = $request->findResourceOrFail();
 
@@ -53,14 +52,7 @@ class UploadController
 
         abort_unless($this->tool->canUpload, 403);
 
-        $this->s3Client = new S3Client([
-            'credentials' => [
-                'key'    => config("filesystems.disks.{$this->tool->disk}.key"),
-                'secret' => config("filesystems.disks.{$this->tool->disk}.secret"),
-            ],
-            'region' => config("filesystems.disks.{$this->tool->disk}.region"),
-            'version' => 'latest',
-        ]);
+        $this->s3Client = app()->makeWith('novas3client', ['disk' => $this->tool->disk]);
     }
 
     /**

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -10,6 +10,19 @@ use Laravel\Nova\Nova;
 
 class ToolServiceProvider extends ServiceProvider
 {
+    public function register()
+    {
+        parent::register();
+
+        // Construct s3 client for tool
+        $this->app->bind('novas3client', function ($app, $args) {
+            $disk = $args['disk'];
+            $config = $this->formatS3Config(config("filesystems.disks.{$disk}"));
+            return new S3Client($config);
+        });
+    }
+
+
     /**
      * Bootstrap any application services.
      *
@@ -24,13 +37,6 @@ class ToolServiceProvider extends ServiceProvider
         Nova::serving(function () {
             Nova::script('nova-s3-multipart-upload', __DIR__ . '/../dist/js/tool.js');
             Nova::style('nova-s3-multipart-upload', __DIR__ . '/../dist/css/tool.css');
-        });
-
-        // Construct s3 client for tool
-        $this->app->bind('novas3client', function ($app, $args) {
-            $disk = $args['disk'];
-            $config = $this->formatS3Config(config("filesystems.disks.{$disk}"));
-            return new S3Client($config);
         });
     }
 

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace Ahmedkandel\NovaS3MultipartUpload;
 
+use Aws\S3\S3Client;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Nova\Nova;
@@ -23,6 +25,30 @@ class ToolServiceProvider extends ServiceProvider
             Nova::script('nova-s3-multipart-upload', __DIR__ . '/../dist/js/tool.js');
             Nova::style('nova-s3-multipart-upload', __DIR__ . '/../dist/css/tool.css');
         });
+
+        // Construct s3 client for tool
+        $this->app->bind('novas3client', function ($app, $args) {
+            $disk = $args['disk'];
+            $config = $this->formatS3Config(config("filesystems.disks.{$disk}"));
+            return new S3Client($config);
+        });
+    }
+
+    /**
+     * Format the given S3 configuration with the default options.
+     *
+     * @param array $config
+     * @return array
+     */
+    protected function formatS3Config(array $config)
+    {
+        $config += ['version' => 'latest'];
+
+        if (!empty($config['key']) && !empty($config['secret'])) {
+            $config['credentials'] = Arr::only($config, ['key', 'secret', 'token']);
+        }
+
+        return $config;
     }
 
     /**


### PR DESCRIPTION
fixes #23

I copied the formatS3Config logic directly from https://github.com/laravel/framework/blob/c0f3ee8c8779d5cfb6bb3c37c93b84672e67f236/src/Illuminate/Filesystem/FilesystemManager.php#L258-L266 to ensure that we supported like-for-like construction of the s3 client.

This ensures that custom config (such as the below) will continue to work.

```php
        'endpoint'                => env('AWS_ENDPOINT'),
        'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
        'options'                 => [
            'CacheControl' => 'public, max-age=2629746, s-maxage=2629746, stale-while-revalidate=2629746',
        ],
```

Once the getDriver() method is available, obviously we can use that, but no reliance on that being available on any specific version of 9.x.

I made an opinionated call and de-privatised the init() method, so that should this method need to be overridden entirely, users could replace the entire UploadController (as I have done myself).

Similarly, I shifted the s3 client construction into a named service in case user code needs to replace with their own logic.